### PR TITLE
Fix relay states and multi-sensor calibration flag clobbering

### DIFF
--- a/RateAppSource/RateController/Classes/clsRelays.cs
+++ b/RateAppSource/RateController/Classes/clsRelays.cs
@@ -177,7 +177,7 @@ namespace RateController.Classes
                 // determine if any section is ON
                 for (int i = 0; i < Props.MaxSections; i++)
                 {
-                    if (Core.Sections.Item(i).IsON)
+                    if (Core.Sections.Item(i).IsON || Props.RateCalibrationOn)
                     {
                         SectionsOn = true;
                         break;

--- a/RateAppSource/RateController/PGNs/PGN32500.cs
+++ b/RateAppSource/RateController/PGNs/PGN32500.cs
@@ -126,6 +126,12 @@ namespace RateController.PGNs
                             cData[9] |= (byte)CommandPGN32500.AutoOn;
                         }
                     }
+                    else
+                    {
+                        // not calibrating this sensor, but keep MasterOn and AutoOn
+                        // set so the module's global flags aren't overwritten
+                        cData[9] |= (byte)(CommandPGN32500.MasterOnMode | CommandPGN32500.AutoOn);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
1. clsRelays.cs: Include RateCalibrationOn in SectionsOn computation so Slave relay activates and Bypass relay deactivates during calibration, matching the forced-on section behavior.

2. PGN32500.cs: Send MasterOn + AutoOn for non-calibrating products when calibration mode is active. This prevents the ESP32 module's global MasterOn/AutoOn flags from being overwritten to 0 by the last PGN32500 on a multi-sensor module.

(cherry picked from commit 1129e7873a54efcd9af6c977ccf2c2118d838216)

This appeared when I was testing the fix created in regards of #56 