### PR TITLE
Add zone list bulk override and import default rate fallback

### DIFF
--- a/RateAppSource/RateController/RateMap/ShapefileHelper.cs
+++ b/RateAppSource/RateController/RateMap/ShapefileHelper.cs
@@ -14,7 +14,7 @@ namespace RateController.RateMap
 {
     public class ShapefileHelper
     {
-        public List<MapZone> CreateZoneList(string shapefilePath, Dictionary<string, string> attributeMapping = null)
+        public List<MapZone> CreateZoneList(string shapefilePath, Dictionary<string, string> attributeMapping = null, Dictionary<string, double> defaultRates = null)
         {
             var zones = new List<MapZone>();
 
@@ -29,7 +29,7 @@ namespace RateController.RateMap
                         {
                             if (feature.Geometry is Polygon)
                             {
-                                var zone = CreateMapZone(feature, (Polygon)feature.Geometry, attributeMapping, index++);
+                                var zone = CreateMapZone(feature, (Polygon)feature.Geometry, attributeMapping, index++, defaultRates);
                                 if (zone != null) zones.Add(zone);
                             }
                             else if (feature.Geometry is MultiPolygon)
@@ -37,7 +37,7 @@ namespace RateController.RateMap
                                 var mp = (MultiPolygon)feature.Geometry;
                                 foreach (Polygon poly in mp.Geometries)
                                 {
-                                    var zone = CreateMapZone(feature, poly, attributeMapping, index++);
+                                    var zone = CreateMapZone(feature, poly, attributeMapping, index++, defaultRates);
                                     if (zone != null) zones.Add(zone);
                                 }
                             }
@@ -204,7 +204,7 @@ namespace RateController.RateMap
             return new[] { g };
         }
 
-        private MapZone CreateMapZone(IFeature feature, Polygon polygon, Dictionary<string, string> mapping, int index)
+        private MapZone CreateMapZone(IFeature feature, Polygon polygon, Dictionary<string, string> mapping, int index, Dictionary<string, double> defaultRates = null)
         {
             try
             {
@@ -241,7 +241,10 @@ namespace RateController.RateMap
                     foreach (var k in rates.Keys.ToList())
                     {
                         string mappedField = mapping.ContainsKey(k) ? mapping[k] : k;
-                        if (feature.Attributes.Exists(mappedField)) rates[k] = Convert.ToDouble(feature.Attributes[mappedField]);
+                        if (feature.Attributes.Exists(mappedField))
+                            rates[k] = Convert.ToDouble(feature.Attributes[mappedField]);
+                        else if (defaultRates != null && defaultRates.TryGetValue(k, out double def))
+                            rates[k] = def;
                     }
 
                     // Map the color

--- a/RateAppSource/RateController/RateMap/frmImport.Designer.cs
+++ b/RateAppSource/RateController/RateMap/frmImport.Designer.cs
@@ -31,9 +31,11 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvMapping = new System.Windows.Forms.DataGridView();
             this.PredefinedAttribute = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ShapeFileAttribute = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.DefaultRateColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.btnSave = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
@@ -72,7 +74,8 @@
             this.dgvMapping.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvMapping.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.PredefinedAttribute,
-            this.ShapeFileAttribute});
+            this.ShapeFileAttribute,
+            this.DefaultRateColumn});
             this.dgvMapping.Location = new System.Drawing.Point(36, 134);
             this.dgvMapping.Name = "dgvMapping";
             this.dgvMapping.RowHeadersVisible = false;
@@ -98,6 +101,16 @@
             this.ShapeFileAttribute.Name = "ShapeFileAttribute";
             this.ShapeFileAttribute.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.ShapeFileAttribute.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // DefaultRateColumn
+            // 
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
+            dataGridViewCellStyle4.Format = "N1";
+            dataGridViewCellStyle4.NullValue = null;
+            this.DefaultRateColumn.DefaultCellStyle = dataGridViewCellStyle4;
+            this.DefaultRateColumn.HeaderText = "Default";
+            this.DefaultRateColumn.Name = "DefaultRate";
+            this.DefaultRateColumn.Width = 80;
             // 
             // btnSave
             // 
@@ -366,6 +379,7 @@
         private System.Windows.Forms.DataGridView dgvMapping;
         private System.Windows.Forms.DataGridViewTextBoxColumn PredefinedAttribute;
         private System.Windows.Forms.DataGridViewComboBoxColumn ShapeFileAttribute;
+        private System.Windows.Forms.DataGridViewTextBoxColumn DefaultRateColumn;
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Label label1;

--- a/RateAppSource/RateController/RateMap/frmImport.cs
+++ b/RateAppSource/RateController/RateMap/frmImport.cs
@@ -24,6 +24,7 @@ namespace RateController.Forms
             InitializeComponent();
             dgvMapping.AutoGenerateColumns = false;
             dgvMapping.AllowUserToAddRows = false;
+            dgvMapping.CellClick += dgvMapping_CellClick;
             rbShapefile.CheckedChanged += new EventHandler(rbMode_CheckedChanged);
             rbXML.CheckedChanged += new EventHandler(rbMode_CheckedChanged);
         }
@@ -166,6 +167,29 @@ namespace RateController.Forms
             }
         }
 
+        private void dgvMapping_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            try
+            {
+                if (e.RowIndex < 0 || e.ColumnIndex < 0) return;
+                if (dgvMapping.Columns[e.ColumnIndex].Name != "DefaultRate") return;
+                if (dgvMapping.Rows[e.RowIndex].Cells[e.ColumnIndex].ReadOnly) return;
+
+                var raw = dgvMapping.Rows[e.RowIndex].Cells[e.ColumnIndex].Value?.ToString() ?? "0";
+                double.TryParse(raw, out double current);
+                using (var form = new AgOpenGPS.FormNumeric(0, 9999, current))
+                {
+                    form.Text = "Default Rate";
+                    if (form.ShowDialog() == DialogResult.OK)
+                        dgvMapping.Rows[e.RowIndex].Cells[e.ColumnIndex].Value = form.ReturnValue.ToString("N1");
+                }
+            }
+            catch (Exception ex)
+            {
+                Props.WriteErrorLog("frmImport/dgvMapping_CellClick: " + ex.Message);
+            }
+        }
+
         private void frmImport_FormClosed(object sender, FormClosedEventArgs e)
         {
             Props.SaveFormLocation(this);
@@ -220,26 +244,32 @@ namespace RateController.Forms
             {
                 string name = _xmlLayerNames[i];
                 if (string.IsNullOrEmpty(name)) continue;
-                int rowIdx = dgvMapping.Rows.Add(ZoneFields.Products[i]);
-                var cell = (DataGridViewComboBoxCell)dgvMapping.Rows[rowIdx].Cells[1];
-                cell.Items.Clear();
-                cell.Items.Add(name);
-                cell.Value = name;
+                int rowIdx = dgvMapping.Rows.Add(ZoneFields.Products[i], name, "");
             }
         }
 
         private void RebuildMapZones()
         {
             attributeMapping = new Dictionary<string, string>();
+            var defaultRates = new Dictionary<string, double>();
             foreach (DataGridViewRow row in dgvMapping.Rows)
             {
                 var predefined = row.Cells["PredefinedAttribute"].Value?.ToString();
                 var shapefileAttribute = row.Cells["ShapefileAttribute"].Value?.ToString();
                 if (!string.IsNullOrEmpty(predefined) && !string.IsNullOrEmpty(shapefileAttribute))
                     attributeMapping[predefined] = shapefileAttribute;
+
+                if (!string.IsNullOrEmpty(predefined) && ZoneFields.Products.Contains(predefined))
+                {
+                    double def = 0;
+                    var defVal = row.Cells["DefaultRate"].Value?.ToString();
+                    if (!string.IsNullOrEmpty(defVal) && double.TryParse(defVal, out double parsed))
+                        def = parsed;
+                    defaultRates[predefined] = def;
+                }
             }
             var shapefileHelper = new ShapefileHelper();
-            _mapZones = shapefileHelper.CreateZoneList(selectedShapefilePath, attributeMapping);
+            _mapZones = shapefileHelper.CreateZoneList(selectedShapefilePath, attributeMapping, defaultRates);
             _simplifiedZones = null;
             _importedZoneCount = _mapZones.Count;
         }
@@ -321,7 +351,11 @@ namespace RateController.Forms
                 if (!string.IsNullOrEmpty(matched))
                     claimed.Add(matched);
 
-                DGV.Rows.Add(predefined, matched);
+                int rowIdx = DGV.Rows.Add(predefined, matched, "");
+                if (!productFields.Contains(predefined))
+                {
+                    DGV.Rows[rowIdx].Cells["DefaultRate"].ReadOnly = true;
+                }
             }
         }
 

--- a/RateAppSource/RateController/RateMap/frmZoneList.Designer.cs
+++ b/RateAppSource/RateController/RateMap/frmZoneList.Designer.cs
@@ -301,7 +301,7 @@
             this.btnCancel.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnCancel.Image = global::RateController.Properties.Resources.Cancel64;
             this.btnCancel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnCancel.Location = new System.Drawing.Point(513, 341);
+            this.btnCancel.Location = new System.Drawing.Point(513, 381);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(70, 63);
             this.btnCancel.TabIndex = 178;
@@ -318,7 +318,7 @@
             this.btnOK.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnOK.Image = global::RateController.Properties.Resources.Save;
             this.btnOK.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnOK.Location = new System.Drawing.Point(589, 341);
+            this.btnOK.Location = new System.Drawing.Point(589, 381);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(70, 63);
             this.btnOK.TabIndex = 177;
@@ -331,7 +331,7 @@
             this.btnDelete.FlatAppearance.BorderSize = 0;
             this.btnDelete.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnDelete.Image = global::RateController.Properties.Resources.Trash;
-            this.btnDelete.Location = new System.Drawing.Point(425, 341);
+            this.btnDelete.Location = new System.Drawing.Point(425, 381);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(82, 64);
             this.btnDelete.TabIndex = 430;
@@ -343,7 +343,7 @@
             this.btnSelect.FlatAppearance.BorderSize = 0;
             this.btnSelect.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnSelect.Image = global::RateController.Properties.Resources.selection;
-            this.btnSelect.Location = new System.Drawing.Point(337, 341);
+            this.btnSelect.Location = new System.Drawing.Point(337, 381);
             this.btnSelect.Name = "btnSelect";
             this.btnSelect.Size = new System.Drawing.Size(82, 64);
             this.btnSelect.TabIndex = 432;
@@ -353,7 +353,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(16, 361);
+            this.label1.Location = new System.Drawing.Point(16, 401);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(60, 24);
             this.label1.TabIndex = 433;
@@ -368,7 +368,7 @@
             this.btnPrint.Font = new System.Drawing.Font("Tahoma", 14.25F);
             this.btnPrint.Image = global::RateController.Properties.Resources.printer;
             this.btnPrint.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnPrint.Location = new System.Drawing.Point(261, 338);
+            this.btnPrint.Location = new System.Drawing.Point(261, 378);
             this.btnPrint.Name = "btnPrint";
             this.btnPrint.Size = new System.Drawing.Size(70, 63);
             this.btnPrint.TabIndex = 434;
@@ -380,7 +380,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(671, 413);
+            this.ClientSize = new System.Drawing.Size(671, 453);
             this.Controls.Add(this.btnPrint);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.btnSelect);

--- a/RateAppSource/RateController/RateMap/frmZoneList.cs
+++ b/RateAppSource/RateController/RateMap/frmZoneList.cs
@@ -16,10 +16,118 @@ namespace RateController.RateMap
         private bool cEdited = false;
         private bool Initializing = false;
         private int _printRow;
+        private ComboBox cboOverrideProduct;
+        private TextBox tbOverrideValue;
+        private Button btnOverrideApply;
 
         public frmZoneList()
         {
             InitializeComponent();
+        }
+
+        private void btnOverrideApply_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (cboOverrideProduct.SelectedIndex < 0)
+                {
+                    System.Media.SystemSounds.Exclamation.Play();
+                    return;
+                }
+
+                double value = 0;
+                if (!double.TryParse(tbOverrideValue.Text, out value))
+                {
+                    using (var form = new FormNumeric(0, 9999, 0))
+                    {
+                        form.Text = "Override Value";
+                        if (form.ShowDialog() == DialogResult.OK)
+                        {
+                            value = form.ReturnValue;
+                            tbOverrideValue.Text = value.ToString("N1");
+                        }
+                        else
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                int colIndex = 3 + cboOverrideProduct.SelectedIndex;
+                bool anySelected = false;
+                foreach (DataGridViewRow row in DGV.Rows)
+                {
+                    if (Convert.ToBoolean(row.Cells[0].Value))
+                    {
+                        row.Cells[colIndex].Value = (decimal)value;
+                        anySelected = true;
+                    }
+                }
+
+                if (!anySelected)
+                {
+                    Props.ShowMessage("No zones selected. Check the zones you want to override.");
+                }
+                else
+                {
+                    SetButtons(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Props.WriteErrorLog("frmZoneList/btnOverrideApply_Click: " + ex.Message);
+            }
+        }
+
+        private void TbOverrideValue_Click(object sender, EventArgs e)
+        {
+            double.TryParse(tbOverrideValue.Text, out double current);
+            using (var form = new FormNumeric(0, 9999, current))
+            {
+                form.Text = "Override Value";
+                if (form.ShowDialog() == DialogResult.OK)
+                    tbOverrideValue.Text = form.ReturnValue.ToString("N1");
+            }
+        }
+
+        private void InitOverrideControls()
+        {
+            int y = DGV.Bottom + 4;
+
+            var lblProduct = new Label();
+            lblProduct.Text = "Product:";
+            lblProduct.AutoSize = true;
+            lblProduct.Location = new Point(DGV.Left, y + 4);
+            this.Controls.Add(lblProduct);
+
+            cboOverrideProduct = new ComboBox();
+            cboOverrideProduct.DropDownStyle = ComboBoxStyle.DropDownList;
+            cboOverrideProduct.Items.AddRange(new object[] { "A", "B", "C", "D", "E" });
+            cboOverrideProduct.SelectedIndex = 0;
+            cboOverrideProduct.Location = new Point(lblProduct.Right + 4, y);
+            cboOverrideProduct.Size = new Size(45, 28);
+            this.Controls.Add(cboOverrideProduct);
+
+            var lblValue = new Label();
+            lblValue.Text = "Value:";
+            lblValue.AutoSize = true;
+            lblValue.Location = new Point(cboOverrideProduct.Right + 8, y + 4);
+            this.Controls.Add(lblValue);
+
+            tbOverrideValue = new TextBox();
+            tbOverrideValue.Location = new Point(lblValue.Right + 4, y);
+            tbOverrideValue.Size = new Size(70, 28);
+            tbOverrideValue.TextAlign = HorizontalAlignment.Right;
+            tbOverrideValue.Click += TbOverrideValue_Click;
+            this.Controls.Add(tbOverrideValue);
+
+            btnOverrideApply = new Button();
+            btnOverrideApply.Text = "Apply";
+            btnOverrideApply.Location = new Point(tbOverrideValue.Right + 6, y - 2);
+            btnOverrideApply.Size = new Size(80, 32);
+            btnOverrideApply.FlatStyle = FlatStyle.Flat;
+            btnOverrideApply.Click += btnOverrideApply_Click;
+            this.Controls.Add(btnOverrideApply);
         }
 
         private void btnCancel_Click(object sender, EventArgs e)
@@ -219,6 +327,7 @@ namespace RateController.RateMap
             this.BackColor = Properties.Settings.Default.MainBackColour;
             DGV.BackgroundColor = DGV.DefaultCellStyle.BackColor;
             DGV.ColumnHeadersDefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+            InitOverrideControls();
             UpdateForm();
             SetButtons(false);
         }


### PR DESCRIPTION
Zone List (frmZoneList):
- Add Product dropdown, Value field, and Apply button below the grid to bulk-fill a chosen product column for all selected (checked) zones.
- Shift bottom buttons down 40px to accommodate the new controls.

Import Prescription (frmImport):
- Add "Default" column to the attribute mapping grid so users can specify a fallback rate per product when the shapefile has no matching attribute. Non-product rows (Name, Color) are read-only.
- Numeric keyboard (FormNumeric) pops up on clicking a Default cell.

ShapefileHelper:
- Extend CreateZoneList / CreateMapZone with an optional defaultRates dictionary; when a shapefile attribute is missing for a product, the default rate is used instead of 0.

(cherry picked from commit d2c8ca3d2a2930769460370098e524a58a1e85f2)